### PR TITLE
Fix Speaker registration button's visibility in mobile view

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -195,5 +195,12 @@
 @media all and (max-width: 767px) {
   .hero-slider .btn-register {
     display: inline-block;
+    margin-bottom: 15px;
+    margin-right: 15px;
+    margin-left: 0px;
+  }
+  .hero-slider .btn{
+    margin-bottom: 15px;
+    margin-right: 8px;
   }
 }

--- a/css/custom.css
+++ b/css/custom.css
@@ -193,11 +193,9 @@
     background-color: transparent;
 }
 @media all and (max-width: 767px) {
-  .hero-slider .btn-register {
+  .hero-slider .btn-hollow {
     display: inline-block;
-    margin-bottom: 15px;
-    margin-right: 15px;
-    margin-left: 0px;
+    margin-left: 0;
   }
   .hero-slider .btn{
     margin-bottom: 15px;

--- a/css/custom.css
+++ b/css/custom.css
@@ -192,3 +192,8 @@
 #myBtn:hover {
     background-color: transparent;
 }
+@media all and (max-width: 767px) {
+  .hero-slider .btn-register {
+    display: inline-block;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -209,7 +209,7 @@
                                 DevSprints 22 May</span>
                                 </h1>
                                 <a target="_self" href="./tickets/" class="btn">Tickets</a>
-                                <a target="_self" href="./speaker-registration/" class="btn btn-hollow inner-link">Speaker Registration</a>
+                                <a target="_self" href="./speaker-registration/" class="btn btn-hollow inner-link btn-register">Speaker Registration</a>
                             </div>
                         </div>
                     </div>

--- a/index.html
+++ b/index.html
@@ -209,7 +209,7 @@
                                 DevSprints 22 May</span>
                                 </h1>
                                 <a target="_self" href="./tickets/" class="btn">Tickets</a>
-                                <a target="_self" href="./speaker-registration/" class="btn btn-hollow inner-link btn-register">Speaker Registration</a>
+                                <a target="_self" href="./speaker-registration/" class="btn btn-hollow inner-link">Speaker Registration</a>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
# Purpose 
The purpose of this PR is to fix issue #1 

# Approach
- Add custom CSS rule for the registration button, to be visible in mobile view.

# Preview 
https://kumuditha-udayanga.github.io/opentechsummit.eu/

# Screenshot
- Before
<img width="482" alt="Screenshot 2019-12-21 at 10 38 57" src="https://user-images.githubusercontent.com/27630091/71303402-2e04cd80-23de-11ea-9590-65639c104d4b.png">

- After
<img width="426" alt="Screenshot 2019-12-21 at 10 38 45" src="https://user-images.githubusercontent.com/27630091/71303407-3ceb8000-23de-11ea-993d-8cba5c07c890.png">

<img width="468" alt="Screenshot 2019-12-21 at 17 36 31" src="https://user-images.githubusercontent.com/27630091/71307712-7214c400-2418-11ea-965d-4029220cb13e.png">





