### PR TITLE
Fix map controls (+, -) and map view on desktop

### DIFF
--- a/css/map-view.css
+++ b/css/map-view.css
@@ -1,0 +1,59 @@
+.map-view iframe {
+    border: 0px;
+    position: absolute;
+    width: 100%;
+    height: 100%;
+  }
+.contact-tweets .map-view {
+    position: absolute;
+    height: 100%;
+    padding: 0px;
+    top: 0px;
+    right: 0px;
+
+  }
+  .map-view:before {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 2;
+    opacity: 0;
+  }
+  .fullwidth-map .map-view {
+    width: 100%;
+    height: 400px;
+    overflow: hidden;
+  }
+  @media all and (max-width: 767px) {
+    .map-view:before {
+        position: relative;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        z-index: 2;
+        opacity: 0;
+      } 
+      .map-view iframe {
+        border: 0px;
+        position: relative;
+        width: 100%;
+        height: 100%;
+      } 
+      .fullwidth-map .map-view {
+        width: 100%;
+        height: 100%;
+        overflow: hidden;
+        bottom: 0px;
+      }
+      .contact-tweets .map-view {
+        position: relative;
+        height: 100%;
+        padding: 0px;
+        top: 0px;
+        right: 0px;
+        
+      }
+  }

--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
         <link href="css/custom-blog.css" rel="stylesheet" type="text/css" media="all"/>
         <link href="css/bootstrap-theme.min.css" rel="stylesheet" type="text/css" media="all"/>
         <link href="css/text-overlay.css" rel="stylesheet" type="text/css" media="all"/>
+        <link href="css/map-view.css" rel="stylesheet" type="text/css" media="all"/>
         <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,600,300' rel='stylesheet' type='text/css'>
         <script>
           // changes email address in homepage to make it responsive according to screen resolutions
@@ -1539,7 +1540,7 @@
                     </div>
                 </div>
             </div>
-            <div class="map-holder col-md-6 col-sm-4 maps">
+            <div class="map-view col-md-6 col-sm-4 maps">
                 <iframe src="https://www.openstreetmap.org/export/embed.html?bbox=13.320783376693727%2C52.51145451459145%2C13.329001665115358%2C52.51563978873906&amp;layer=mapnik&amp;marker=52.513547201492564%2C13.324892520904541"></iframe>
             </div>
         </section>


### PR DESCRIPTION
# Purpose
This is to fix issue #9 and the current desktop map view.

# Process
Created new css class for map view and updated it with new options. Changed class of current map view to new class which allowed controls to work. Added css rule using media query to allow mobile to work as well.

# Preview
View the working +/- controls and updates at https://pranavkarthik10.github.io/opentechsummit.eu/

**Before**
- Desktop
![Screen Shot 2019-12-22 at 7 54 06 PM](https://user-images.githubusercontent.com/44630385/71335295-e32aa900-24f6-11ea-8520-64473e5a7b1e.png)
- Mobile
![Screen Shot 2019-12-22 at 7 54 45 PM](https://user-images.githubusercontent.com/44630385/71335297-e7ef5d00-24f6-11ea-8a4a-2a1ba4ea3262.png)

**After**
- Desktop
![Screen Shot 2019-12-22 at 7 51 03 PM](https://user-images.githubusercontent.com/44630385/71335286-d443f680-24f6-11ea-8b96-96276c7eef88.png)
- Mobile
![Screen Shot 2019-12-22 at 7 53 41 PM](https://user-images.githubusercontent.com/44630385/71335300-eaea4d80-24f6-11ea-880f-7259cce5a1dd.png)
